### PR TITLE
Fix WebSocket timeout and heartbeat settings

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -75,7 +75,7 @@ spring.websocket.max-binary-message-size=4194304
 # WebSocket Configuration for Audio Streaming - optimized for low latency
 spring.websocket.max-binary-message-buffer-size=65536   # 64KB - reduced for low latency streaming
 spring.websocket.max-text-message-buffer-size=32768     # 32KB - reduced for low latency streaming
-spring.websocket.max-session-idle-timeout=120000
+spring.websocket.max-session-idle-timeout=600000
 
 # FFmpeg Streaming Configuration for Icecast - enhanced for cloud stability and race condition handling
 ffmpeg.reconnect.enabled=true
@@ -88,7 +88,7 @@ ffmpeg.retry.attempts=8
 spring.profiles.active=${SPRING_PROFILES_ACTIVE}
 
 # Network timeouts for cloud deployment - increased for cross-region connections
-server.tomcat.connection-timeout=120000
+server.tomcat.connection-timeout=600000
 server.tomcat.max-connections=400
 server.tomcat.accept-count=200
 
@@ -106,7 +106,7 @@ management.endpoints.web.cors.allowed-methods=GET,POST,PUT,DELETE,OPTIONS
 management.endpoints.web.cors.allowed-headers=*
 
 # Additional CORS support for WebSocket upgrades - optimized for low latency
-spring.websocket.sockjs.heartbeat-time=15000
+spring.websocket.sockjs.heartbeat-time=30000
 spring.websocket.sockjs.disconnect-delay=2000
 spring.websocket.sockjs.client-library-url=https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js
 

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -98,7 +98,7 @@ export const config = {
   // WebSocket Configuration
   wsReconnectDelay: isLocalEnvironment ? 3000 : 5000,
   wsReconnectJitter: isLocalEnvironment ? 1000 : 2000,
-  wsHeartbeatInterval: isLocalEnvironment ? 10000 : 25000,
+  wsHeartbeatInterval: isLocalEnvironment ? 10000 : 20000,
   wsMaxReconnectAttempts: isLocalEnvironment ? 5 : 10,
 
   // Audio/Media Configuration


### PR DESCRIPTION
## Summary
- extend backend WebSocket idle timeout
- adjust frontend heartbeat interval
- adjust server connection timeout and sockjs heartbeat to match docs

## Testing
- `npm run lint` *(fails: cannot find lint script)*
- `./mvnw test` *(fails: maven wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881e0c983b0832b8893a77800164317