### PR TITLE
Add persistent mini player and log broadcast starter

### DIFF
--- a/backend/src/main/java/com/wildcastradio/Broadcast/BroadcastEntity.java
+++ b/backend/src/main/java/com/wildcastradio/Broadcast/BroadcastEntity.java
@@ -55,6 +55,10 @@ public class BroadcastEntity {
     @JoinColumn(name = "created_by_id", nullable = false)
     private UserEntity createdBy;
 
+    @ManyToOne
+    @JoinColumn(name = "started_by_id")
+    private UserEntity startedBy;
+
     @OneToOne
     @JoinColumn(name = "schedule_id", nullable = false)
     private ScheduleEntity schedule;
@@ -76,8 +80,8 @@ public class BroadcastEntity {
     
     // All args constructor
     public BroadcastEntity(Long id, String title, String description, LocalDateTime actualStart,
-                          LocalDateTime actualEnd, BroadcastStatus status, String streamUrl, 
-                          UserEntity createdBy, ScheduleEntity schedule,
+                          LocalDateTime actualEnd, BroadcastStatus status, String streamUrl,
+                          UserEntity createdBy, UserEntity startedBy, ScheduleEntity schedule,
                           List<ChatMessageEntity> chatMessages, List<SongRequestEntity> songRequests) {
         this.id = id;
         this.title = title;
@@ -87,6 +91,7 @@ public class BroadcastEntity {
         this.status = status;
         this.streamUrl = streamUrl;
         this.createdBy = createdBy;
+        this.startedBy = startedBy;
         this.schedule = schedule;
         this.chatMessages = chatMessages;
         this.songRequests = songRequests;
@@ -156,6 +161,14 @@ public class BroadcastEntity {
 
     public void setCreatedBy(UserEntity createdBy) {
         this.createdBy = createdBy;
+    }
+
+    public UserEntity getStartedBy() {
+        return startedBy;
+    }
+
+    public void setStartedBy(UserEntity startedBy) {
+        this.startedBy = startedBy;
     }
 
     public ScheduleEntity getSchedule() {

--- a/backend/src/main/java/com/wildcastradio/Broadcast/BroadcastService.java
+++ b/backend/src/main/java/com/wildcastradio/Broadcast/BroadcastService.java
@@ -214,6 +214,7 @@ public class BroadcastService {
 
         broadcast.setActualStart(LocalDateTime.now());
         broadcast.setStatus(BroadcastEntity.BroadcastStatus.LIVE);
+        broadcast.setStartedBy(dj);
 
         BroadcastEntity savedBroadcast = broadcastRepository.save(broadcast);
 

--- a/backend/src/main/java/com/wildcastradio/Broadcast/DTO/BroadcastDTO.java
+++ b/backend/src/main/java/com/wildcastradio/Broadcast/DTO/BroadcastDTO.java
@@ -17,6 +17,7 @@ public class BroadcastDTO {
     private String status;
     private String streamUrl;
     private UserDTO createdBy;
+    private UserDTO startedBy;
     
     // For displaying formatted dates in frontend
     private String formattedStart;
@@ -28,7 +29,7 @@ public class BroadcastDTO {
     
     public BroadcastDTO(Long id, String title, String description, LocalDateTime scheduledStart,
                        LocalDateTime scheduledEnd, LocalDateTime actualStart, LocalDateTime actualEnd,
-                       String status, String streamUrl, UserDTO createdBy) {
+                       String status, String streamUrl, UserDTO createdBy, UserDTO startedBy) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -39,6 +40,7 @@ public class BroadcastDTO {
         this.status = status;
         this.streamUrl = streamUrl;
         this.createdBy = createdBy;
+        this.startedBy = startedBy;
         
         // Format the dates for frontend display
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
@@ -60,6 +62,11 @@ public class BroadcastDTO {
         if (broadcast.getCreatedBy() != null) {
             userDTO = UserDTO.fromEntity(broadcast.getCreatedBy());
         }
+
+        UserDTO startedByDTO = null;
+        if (broadcast.getStartedBy() != null) {
+            startedByDTO = UserDTO.fromEntity(broadcast.getStartedBy());
+        }
         
         return new BroadcastDTO(
             broadcast.getId(),
@@ -71,7 +78,8 @@ public class BroadcastDTO {
             broadcast.getActualEnd(),
             broadcast.getStatus().toString(),
             broadcast.getStreamUrl(),
-            userDTO
+            userDTO,
+            startedByDTO
         );
     }
     
@@ -154,6 +162,14 @@ public class BroadcastDTO {
     
     public void setCreatedBy(UserDTO createdBy) {
         this.createdBy = createdBy;
+    }
+
+    public UserDTO getStartedBy() {
+        return startedBy;
+    }
+
+    public void setStartedBy(UserDTO startedBy) {
+        this.startedBy = startedBy;
     }
     
     public String getFormattedStart() {

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -3,6 +3,7 @@ import { Outlet } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import NewSidebar from './Sidebar';
 import Header from './Header';
+import MiniPlayer from './MiniPlayer';
 import { SidebarProvider } from './ui/sidebar';
 import { EnhancedScrollArea } from './ui/enhanced-scroll-area';
 
@@ -43,6 +44,7 @@ const Layout = ({ children }) => {
           <Outlet />
           {children}
         </MainContent>
+        <MiniPlayer />
       </div>
     </SidebarProvider>
   );

--- a/frontend/src/components/MiniPlayer.jsx
+++ b/frontend/src/components/MiniPlayer.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { PlayIcon, PauseIcon } from '@heroicons/react/24/solid';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useStreaming } from '../context/StreamingContext';
+
+const MiniPlayer = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { audioPlaying, toggleAudio, currentBroadcast, isLive } = useStreaming();
+
+  // Hide on listener dashboard views
+  if (location.pathname === '/dashboard' || location.pathname.startsWith('/broadcast')) {
+    return null;
+  }
+
+  // Only show if there's an active broadcast or playback
+  if (!isLive && !audioPlaying) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-maroon-800 text-white z-50 flex items-center justify-between px-4 py-2 shadow-lg">
+      <div className="flex items-center space-x-2">
+        <span className="font-medium truncate max-w-[50vw]">
+          {currentBroadcast?.title || 'Live Broadcast'}
+        </span>
+        {isLive && (
+          <span className="text-xs bg-red-600 rounded px-2 py-0.5">LIVE</span>
+        )}
+      </div>
+      <div className="flex items-center space-x-4">
+        <button
+          onClick={toggleAudio}
+          className="p-2 rounded-full bg-white/20 hover:bg-white/30"
+        >
+          {audioPlaying ? (
+            <PauseIcon className="h-5 w-5" />
+          ) : (
+            <PlayIcon className="h-5 w-5" />
+          )}
+        </button>
+        <button
+          onClick={() => navigate('/dashboard')}
+          className="text-xs underline"
+        >
+          Open Player
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MiniPlayer;


### PR DESCRIPTION
## Summary
- implement a `MiniPlayer` component that persists across pages
- render `MiniPlayer` in the global `Layout`
- track which DJ started a broadcast via new `startedBy` relationship
- expose started-by information through `BroadcastDTO`
- store started-by value when a broadcast is begun

## Testing
- `npm run lint` *(fails: 90 problems)*
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887469cc1ac832b85d331d2b01d0f78