### PR TITLE
Keep audio playing via mini player

### DIFF
--- a/frontend/src/components/MiniPlayer.jsx
+++ b/frontend/src/components/MiniPlayer.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { PlayIcon, PauseIcon } from '@heroicons/react/24/solid';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useStreaming } from '../context/StreamingContext';
+import { useAuth } from '../context/AuthContext';
 
 const MiniPlayer = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { currentUser } = useAuth();
   const { audioPlaying, toggleAudio, currentBroadcast, isLive } = useStreaming();
 
   // Hide on listener dashboard views
@@ -13,25 +15,30 @@ const MiniPlayer = () => {
     return null;
   }
 
-  // Only show if there's an active broadcast or playback
-  if (!isLive && !audioPlaying) {
+  // Only students should see the mini player
+  if (currentUser?.role !== 'STUDENT') {
+    return null;
+  }
+
+  // Only show if there's an active broadcast
+  if (!isLive) {
     return null;
   }
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 bg-maroon-800 text-white z-50 flex items-center justify-between px-4 py-2 shadow-lg">
-      <div className="flex items-center space-x-2">
-        <span className="font-medium truncate max-w-[50vw]">
+    <div className="fixed bottom-0 left-0 right-0 bg-gradient-to-r from-maroon-700 via-maroon-800 to-maroon-700 text-white z-50 flex items-center justify-between px-4 py-2 shadow-xl border-t border-maroon-900">
+      <div className="flex items-center space-x-3 overflow-hidden">
+        <span className="font-semibold truncate max-w-[60vw]">
           {currentBroadcast?.title || 'Live Broadcast'}
         </span>
         {isLive && (
-          <span className="text-xs bg-red-600 rounded px-2 py-0.5">LIVE</span>
+          <span className="text-xs bg-red-600 rounded px-2 py-0.5 animate-pulse">LIVE</span>
         )}
       </div>
       <div className="flex items-center space-x-4">
         <button
           onClick={toggleAudio}
-          className="p-2 rounded-full bg-white/20 hover:bg-white/30"
+          className="p-2 rounded-full bg-white/20 hover:bg-white/30 transition"
         >
           {audioPlaying ? (
             <PauseIcon className="h-5 w-5" />
@@ -41,7 +48,7 @@ const MiniPlayer = () => {
         </button>
         <button
           onClick={() => navigate('/dashboard')}
-          className="text-xs underline"
+          className="text-xs underline hover:text-gray-200"
         >
           Open Player
         </button>

--- a/frontend/src/pages/ListenerDashboard.jsx
+++ b/frontend/src/pages/ListenerDashboard.jsx
@@ -41,7 +41,8 @@ export default function ListenerDashboard() {
     toggleAudio,
     updateVolume,
     toggleMute,
-    serverConfig
+    serverConfig,
+    audioRef
   } = useStreaming();
 
   // If we're accessing a specific broadcast by ID, set it as the current broadcast
@@ -85,6 +86,11 @@ export default function ListenerDashboard() {
   // Local audio state for the dashboard player (separate from streaming context)
   const [localAudioPlaying, setLocalAudioPlaying] = useState(false);
 
+  // Sync local audio state with global streaming context
+  useEffect(() => {
+    setLocalAudioPlaying(audioPlaying);
+  }, [audioPlaying]);
+
   // Local listener count state (fallback if streaming context doesn't update)
   const [localListenerCount, setLocalListenerCount] = useState(0);
 
@@ -112,7 +118,6 @@ export default function ListenerDashboard() {
   const abortControllerRef = useRef(null);
 
   // Audio refs from ListenerDashboard2.jsx
-  const audioRef = useRef(null);
   const statusCheckInterval = useRef(null);
 
   // Add state for listener WebSocket connection
@@ -260,12 +265,7 @@ export default function ListenerDashboard() {
     }
 
     return () => {
-      // Cleanup audio element on unmount
-      if (audioRef.current) {
-        audioRef.current.pause();
-        audioRef.current.src = '';
-        audioRef.current = null;
-      }
+      // Do not stop the audio on unmount so the MiniPlayer can continue playing
     };
   }, [serverConfig, volume, isMuted]);
 


### PR DESCRIPTION
## Summary
- redesign MiniPlayer and limit visibility
- sync listener dashboard audio state with global StreamingContext
- keep audio element alive when leaving ListenerDashboard

## Testing
- `npm run lint` *(fails: ESLint config missing packages and lint errors)*
- `mvn -q -pl backend test` *(fails: couldn't resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688759a42060832bbeaa9ca99cdbb8f1